### PR TITLE
LIDO: use driverparam when deciding default language

### DIFF
--- a/src/RecordManager/Finna/Record/Lido.php
+++ b/src/RecordManager/Finna/Record/Lido.php
@@ -651,7 +651,7 @@ class Lido extends \RecordManager\Base\Record\Lido
      */
     protected function getDefaultLanguage()
     {
-        return 'fi';
+        return $this->getDriverParam('defaultDisplayLanguage', 'fi');
     }
 
     /**


### PR DESCRIPTION
Defaults to 'fi'