### PR TITLE
[ALLI-7839] EAD3: Fix appending year range to titles

### DIFF
--- a/src/RecordManager/Finna/Record/DateSupportTrait.php
+++ b/src/RecordManager/Finna/Record/DateSupportTrait.php
@@ -73,6 +73,29 @@ trait DateSupportTrait
      *
      * @return array [startYear, endYear] or empty array if not found.
      */
+    protected function getYearRangeFromString(string $dateString): array
+    {
+        if ($years = $this->getYearsFromString($dateString)) {
+            $result = [
+                'startYear' => $years[0],
+                'endYear' => $years[1] ?? $years[0]
+            ];
+            // Turn the years into numbers and compare them.
+            if ((int)$result['startYear'] > (int)$result['endYear']) {
+                $result['endYear'] = $result['startYear'];
+            }
+            return $result;
+        }
+        return [];
+    }
+
+    /**
+     * Get years from a string. Returns array containing all found 4 digit years.
+     *
+     * @param string $dateString String to check for years.
+     *
+     * @return array
+     */
     protected function getYearsFromString(string $dateString): array
     {
         if (preg_match_all(
@@ -81,15 +104,7 @@ trait DateSupportTrait
             $matches
         )
         ) {
-            $result = [
-                'startYear' => $matches[1][0],
-                'endYear' => $matches[1][1] ?? $matches[1][0]
-            ];
-            // Turn the years into numbers and compare them.
-            if ((int)$result['startYear'] > (int)$result['endYear']) {
-                $result['endYear'] = $result['startYear'];
-            }
-            return $result;
+            return $matches[1];
         }
         return [];
     }

--- a/src/RecordManager/Finna/Record/Ead3.php
+++ b/src/RecordManager/Finna/Record/Ead3.php
@@ -298,13 +298,16 @@ class Ead3 extends \RecordManager\Base\Record\Ead3
          * Type of enrichment for driver.
          * always = Always add year range to end of a title
          * never = Do not add year range to end of a title
-         * noyearexists = If any year is found from the title then do not add
-         * nomatchexists = If any of the given years in unitDateRange are
+         * no_year_exist = If any year is found from the title then do not add
+         * no_match_exist = If any of the given years in unitDateRange are
          * found from the title, then do not add
-         * nomatchesexists = If all of the given years in unitDateRange are
+         * no_matches_exist = If all of the given years in unitDateRange are
          * found from the title, then do not add
          */
-        $type = $this->getDriverParam('enrichTitleWithYearRange', 'nomatchesexists');
+        $type = $this->getDriverParam(
+            'enrichTitleWithYearRange',
+            'no_matches_exist'
+        );
         if ('never' === $type) {
             return $data;
         }
@@ -330,17 +333,17 @@ class Ead3 extends \RecordManager\Base\Record\Ead3
                 case 'always':
                     $data[$field] .= $yearRangeStr;
                     break;
-                case 'noyearexists':
+                case 'no_year_exist':
                     if (!$yearsFound) {
                         $data[$field] .= $yearRangeStr;
                     }
                     break;
-                case 'nomatchexists':
+                case 'no_match_exist':
                     if (!array_intersect($yearRange, $yearsFound)) {
                         $data[$field] .= $yearRangeStr;
                     }
                     break;
-                case 'nomatchesexists':
+                case 'no_matches_exist':
                     $yearRange = array_filter(array_unique($yearRange));
                     if (array_intersect($yearRange, $yearsFound) !== $yearRange) {
                         $data[$field] .= $yearRangeStr;

--- a/src/RecordManager/Finna/Record/Ead3.php
+++ b/src/RecordManager/Finna/Record/Ead3.php
@@ -296,7 +296,7 @@ class Ead3 extends \RecordManager\Base\Record\Ead3
     ): array {
         /**
          * Type of enrichment for driver.
-         * always = always add year range to end of a title
+         * always = Always add year range to end of a title
          * never = Do not add year range to end of a title
          * noyearexists = If any year is found from the title then do not add
          * nomatchexists = If any of the given years in unitDateRange are
@@ -304,17 +304,12 @@ class Ead3 extends \RecordManager\Base\Record\Ead3
          * nomatchesexists = if all of the given years in unitDateRange are
          * found from the title, then do not add
          */
-        $type = $this->getDriverParam('enrichTitleWithYearRange', 'noyearexists');
+        $type = $this->getDriverParam('enrichTitleWithYearRange', 'nomatchesexists');
         if ('never' === $type) {
             return $data;
         }
-
-        $startDateUnknown = $unitDateRange['startDateUnknown'];
-        $range = $unitDateRange['date'];
-
-        if (!$startDateUnknown) {
-            // When startDate is known, Append year range to title
-            // (only years, not the full dates)
+        if (!$unitDateRange['startDateUnknown']) {
+            $range = $unitDateRange['date'];
             $startYear
                 = $this->metadataUtils->extractYear($range[0]);
             $endYear = $this->metadataUtils->extractYear($range[1]);

--- a/src/RecordManager/Finna/Record/Ead3.php
+++ b/src/RecordManager/Finna/Record/Ead3.php
@@ -298,15 +298,15 @@ class Ead3 extends \RecordManager\Base\Record\Ead3
          * Type of enrichment for driver.
          * always = Always add year range to end of a title
          * never = Do not add year range to end of a title
-         * no_year_exist = If any year is found from the title then do not add
-         * no_match_exist = If any of the given years in unitDateRange are
+         * no_year_exists = If any year is found from the title then do not add
+         * no_match_exists = If any of the given years in unitDateRange are
          * found from the title, then do not add
          * no_matches_exist = If all of the given years in unitDateRange are
          * found from the title, then do not add
          */
         $type = $this->getDriverParam(
             'enrichTitleWithYearRange',
-            'no_match_exist'
+            'no_match_exists'
         );
         if ('never' === $type) {
             return $data;
@@ -333,12 +333,12 @@ class Ead3 extends \RecordManager\Base\Record\Ead3
                 case 'always':
                     $data[$field] .= $yearRangeStr;
                     break;
-                case 'no_year_exist':
+                case 'no_year_exists':
                     if (!$yearsFound) {
                         $data[$field] .= $yearRangeStr;
                     }
                     break;
-                case 'no_match_exist':
+                case 'no_match_exists':
                     if (!array_intersect($yearRange, $yearsFound)) {
                         $data[$field] .= $yearRangeStr;
                     }

--- a/src/RecordManager/Finna/Record/Ead3.php
+++ b/src/RecordManager/Finna/Record/Ead3.php
@@ -301,7 +301,7 @@ class Ead3 extends \RecordManager\Base\Record\Ead3
          * noyearexists = If any year is found from the title then do not add
          * nomatchexists = If any of the given years in unitDateRange are
          * found from the title, then do not add
-         * nomatchesexists = if all of the given years in unitDateRange are
+         * nomatchesexists = If all of the given years in unitDateRange are
          * found from the title, then do not add
          */
         $type = $this->getDriverParam('enrichTitleWithYearRange', 'nomatchesexists');

--- a/src/RecordManager/Finna/Record/Ead3.php
+++ b/src/RecordManager/Finna/Record/Ead3.php
@@ -341,6 +341,7 @@ class Ead3 extends \RecordManager\Base\Record\Ead3
                     }
                     break;
                 case 'nomatchesexists':
+                    $yearRange = array_filter(array_unique($yearRange));
                     if (array_intersect($yearRange, $yearsFound) !== $yearRange) {
                         $data[$field] .= $yearRangeStr;
                     }

--- a/src/RecordManager/Finna/Record/Ead3.php
+++ b/src/RecordManager/Finna/Record/Ead3.php
@@ -115,7 +115,6 @@ class Ead3 extends \RecordManager\Base\Record\Ead3
                     $endYear = $this->metadataUtils->extractYear($unitDateRange[1]);
                     $yearRange = '';
                     $ndash = html_entity_decode('&#x2013;', ENT_NOQUOTES, 'UTF-8');
-                    $mdash = html_entity_decode('&#x2014;', ENT_NOQUOTES, 'UTF-8');
                     if ($startYear != '-9999') {
                         $yearRange = $startYear;
                     }
@@ -126,13 +125,11 @@ class Ead3 extends \RecordManager\Base\Record\Ead3
                         }
                     }
                     if ($yearRange) {
-                        $reg = '/(\(?)(\d{4})[\p{Pd}'
-                            . $ndash . $mdash . '\h]+(\d{4})(\)?)$/';
                         foreach (
                             ['title_full', 'title_sort', 'title', 'title_short']
                             as $field
                         ) {
-                            if (!preg_match($reg, $data[$field])) {
+                            if (!$this->getYearsFromString($data[$field])) {
                                 $data[$field] .= " ($yearRange)";
                             }
                         }

--- a/src/RecordManager/Finna/Record/Ead3.php
+++ b/src/RecordManager/Finna/Record/Ead3.php
@@ -306,7 +306,7 @@ class Ead3 extends \RecordManager\Base\Record\Ead3
          */
         $type = $this->getDriverParam(
             'enrichTitleWithYearRange',
-            'no_matches_exist'
+            'no_match_exist'
         );
         if ('never' === $type) {
             return $data;

--- a/src/RecordManager/Finna/Record/QdcRecordTrait.php
+++ b/src/RecordManager/Finna/Record/QdcRecordTrait.php
@@ -255,7 +255,7 @@ trait QdcRecordTrait
         $result = [];
         foreach ([$this->doc->date, $this->doc->issued] as $arr) {
             foreach ($arr as $date) {
-                $years = $this->getYearsFromString($date);
+                $years = $this->getYearRangeFromString($date);
                 if (isset($years['startYear'])) {
                     $result[] = [
                         $years['startYear'] . '-01-01T00:00:00Z',

--- a/tests/RecordManagerTest/Finna/Record/Ead3Test.php
+++ b/tests/RecordManagerTest/Finna/Record/Ead3Test.php
@@ -380,7 +380,7 @@ class Ead3Test extends \RecordManagerTest\Base\Record\RecordTest
         return [
             [
                 'driverParams' => [
-                    'enrichTitleWithYearRange=noyearexists'
+                    'enrichTitleWithYearRange=no_year_exist'
                 ],
                 'tests' => $noYear
             ],
@@ -392,14 +392,14 @@ class Ead3Test extends \RecordManagerTest\Base\Record\RecordTest
             ],
             [
                 'driverParams' => [
-                    'enrichTitleWithYearRange=nomatchexists'
+                    'enrichTitleWithYearRange=no_match_exist'
                 ],
                 'tests' => $noMatch
             ],
             [
 
                 'driverParams' => [
-                    'enrichTitleWithYearRange=nomatchesexists'
+                    'enrichTitleWithYearRange=no_matches_exist'
                 ],
                 'tests' => $noMatches
             ],

--- a/tests/RecordManagerTest/Finna/Record/Ead3Test.php
+++ b/tests/RecordManagerTest/Finna/Record/Ead3Test.php
@@ -257,76 +257,197 @@ class Ead3Test extends \RecordManagerTest\Base\Record\RecordTest
     /**
      * Data provider for testTitleYearRange
      *
-     * @return Generator
+     * @return Array
      */
     public function getTestTitleYearRange()
     {
         $ndash = html_entity_decode('&#x2013;', ENT_NOQUOTES, 'UTF-8');
         $mdash = html_entity_decode('&#x2014;', ENT_NOQUOTES, 'UTF-8');
-        $this->modifyAhaa14Fixture(
-            "Opintokirja. Helsingin yliopisto (1932{$ndash}1935)"
-        );
-        $record = $this->createRecord(Ead3::class, 'ahaa14.xml', [], 'Finna')
-            ->toSolrArray();
-        yield 'test ndash' => [
-            "Opintokirja. Helsingin yliopisto (1932{$ndash}1935)",
-            $record['title']
+
+        $noYear = [
+            'test ndash' => [
+                'title' => "Opintokirja. Helsingin yliopisto (1932{$ndash}1935)",
+                'expected' => "Opintokirja. Helsingin yliopisto (1932{$ndash}1935)",
+            ],
+            'test mdash' => [
+                'title' => "Opintokirja. Helsingin yliopisto 1932{$mdash}1935",
+                'expected' => "Opintokirja. Helsingin yliopisto 1932{$mdash}1935",
+            ],
+            'test dash' => [
+                'title' => "Opintokirja. Helsingin yliopisto (1932 - 1935)",
+                'expected' => "Opintokirja. Helsingin yliopisto (1932 - 1935)",
+            ],
+            'test dash without whitespaces' => [
+                'title' => "Opintokirja. Helsingin yliopisto 1932-1935",
+                'expected' => "Opintokirja. Helsingin yliopisto 1932-1935",
+            ],
+            'test without year range' => [
+                'title' => "Opintokirja. Helsingin yliopisto",
+                'expected' => "Opintokirja. Helsingin yliopisto (1932{$ndash}1935)",
+            ],
         ];
 
-        $this->modifyAhaa14Fixture(
-            "Opintokirja. Helsingin yliopisto 1932{$mdash}1935"
-        );
-        $record = $this->createRecord(Ead3::class, 'ahaa14.xml', [], 'Finna')
-            ->toSolrArray();
-        yield 'test mdash' => [
-            "Opintokirja. Helsingin yliopisto 1932{$mdash}1935",
-            $record['title']
+        $never = [
+            'test ndash' => [
+                'title' => "Opintokirja. Helsingin yliopisto (1932{$ndash}1935)",
+                'expected' => "Opintokirja. Helsingin yliopisto (1932{$ndash}1935)",
+            ],
+            'test without year range' => [
+                'title' => "Opintokirja. Helsingin yliopisto",
+                'expected' => "Opintokirja. Helsingin yliopisto",
+            ]
         ];
 
-        $this->modifyAhaa14Fixture(
-            "Opintokirja. Helsingin yliopisto (1932 - 1935)"
-        );
-        $record = $this->createRecord(Ead3::class, 'ahaa14.xml', [], 'Finna')
-            ->toSolrArray();
-        yield 'test dash' => [
-            "Opintokirja. Helsingin yliopisto (1932 - 1935)",
-            $record['title']
+        $noMatch = [
+            'test ndash' => [
+                'title' => "Opintokirja. Helsingin yliopisto (1932{$ndash}1935)",
+                'expected' => "Opintokirja. Helsingin yliopisto (1932{$ndash}1935)",
+            ],
+            'test mdash' => [
+                'title' => "Opintokirja. Helsingin yliopisto 1932{$mdash}1935",
+                'expected' => "Opintokirja. Helsingin yliopisto 1932{$mdash}1935",
+            ],
+            'test dash' => [
+                'title' => "Opintokirja. Helsingin yliopisto (1932 - 1935)",
+                'expected' => "Opintokirja. Helsingin yliopisto (1932 - 1935)",
+            ],
+            'test dash without whitespaces' => [
+                'title' => "Opintokirja. 1932 Helsingin yliopisto",
+                'expected' => "Opintokirja. 1932 Helsingin yliopisto",
+            ],
+            'test without year range' => [
+                'title' => "Opintokirja. Helsingin yliopisto",
+                'expected' => "Opintokirja. Helsingin yliopisto (1932{$ndash}1935)",
+            ],
         ];
 
-        $this->modifyAhaa14Fixture(
-            "Opintokirja. Helsingin yliopisto 1932-1935"
-        );
-        $record = $this->createRecord(Ead3::class, 'ahaa14.xml', [], 'Finna')
-            ->toSolrArray();
-        yield 'test dash without whitespaces' => [
-            "Opintokirja. Helsingin yliopisto 1932-1935",
-            $record['title']
+        $noMatches = [
+            'no matches ndash' => [
+                'title' => "Opintokirja. Helsingin yliopisto (1932{$ndash}1935)",
+                'expected' => "Opintokirja. Helsingin yliopisto (1932{$ndash}1935)",
+            ],
+            'no matches mdash' => [
+                'title' => "Opintokirja. Helsingin yliopisto 1932{$mdash}1935",
+                'expected' => "Opintokirja. Helsingin yliopisto 1932{$mdash}1935",
+            ],
+            'no matches dash' => [
+                'title' => "Opintokirja. Helsingin yliopisto (1932)",
+                'expected'
+                    => "Opintokirja. Helsingin yliopisto (1932) (1932{$ndash}1935)",
+            ],
+            'no matches with years' => [
+                'title' => "Opintokirja. 1932 Helsingin yliopisto 1935",
+                'expected' => "Opintokirja. 1932 Helsingin yliopisto 1935 (1932{$ndash}1935)",
+            ],
+            'no matches without years' => [
+                'title' => "Opintokirja. Helsingin yliopisto",
+                'expected' => "Opintokirja. Helsingin yliopisto (1932{$ndash}1935)",
+            ],
         ];
 
-        $this->modifyAhaa14Fixture("Opintokirja. Helsingin yliopisto");
-        $record = $this->createRecord(Ead3::class, 'ahaa14.xml', [], 'Finna')
-            ->toSolrArray();
-        yield 'test without year range' => [
-            "Opintokirja. Helsingin yliopisto (1932{$ndash}1935)",
-            $record['title']
+        $always = [
+            'always ndash' => [
+                'title' => "Opintokirja. Helsingin yliopisto (1932{$ndash}1935)",
+                'expected' => "Opintokirja. Helsingin yliopisto (1932{$ndash}1935)",
+            ],
+            'always mdash' => [
+                'title' => "Opintokirja. Helsingin yliopisto 1932{$mdash}1935",
+                'expected'
+                    => "Opintokirja. Helsingin yliopisto 1932{$mdash}1935 (1932{$ndash}1935)",
+            ],
+            'always dash' => [
+                'title' => "Opintokirja. Helsingin yliopisto (1932 - 1935)",
+                'expected' =>
+                    "Opintokirja. Helsingin yliopisto (1932 - 1935) (1932{$ndash}1935)",
+            ],
+            'always title with a year' => [
+                'title' => "Opintokirja. 1932 Helsingin yliopisto",
+                'expected'
+                    => "Opintokirja. 1932 Helsingin yliopisto (1932{$ndash}1935)",
+            ],
+            'always without year' => [
+                'title' => "Opintokirja. Helsingin yliopisto",
+                'expected' => "Opintokirja. Helsingin yliopisto (1932{$ndash}1935)",
+            ],
         ];
-        // Set the fixture title to its original state after tests
-        $this->modifyAhaa14Fixture("%%title%%");
+
+        return [
+            [
+                'dsSettings' => [
+                    '__unit_test_no_source__' => [
+                        'driverParams' => [
+                            'enrichTitleWithYearRange=noyearexists'
+                        ]
+                    ]
+                ],
+                'tests' => $noYear
+            ],
+            [
+                'dsSettings' => [
+                    '__unit_test_no_source__' => [
+                        'driverParams' => [
+                            'enrichTitleWithYearRange=never'
+                        ]
+                    ]
+                ],
+                'tests' => $never
+            ],
+            [
+                'dsSettings' => [
+                    '__unit_test_no_source__' => [
+                        'driverParams' => [
+                            'enrichTitleWithYearRange=nomatchexists'
+                        ]
+                    ]
+                ],
+                'tests' => $noMatch
+            ],
+            [
+                'dsSettings' => [
+                    '__unit_test_no_source__' => [
+                        'driverParams' => [
+                            'enrichTitleWithYearRange=nomatchesexists'
+                        ]
+                    ]
+                ],
+                'tests' => $noMatches
+            ],
+            [
+                'dsSettings' => [
+                    '__unit_test_no_source__' => [
+                        'driverParams' => [
+                            'enrichTitleWithYearRange=always'
+                        ]
+                    ]
+                ],
+                'tests' => $always
+            ],
+        ];
     }
 
     /**
      * Test AHAA EAD3 title year range handling
      *
-     * @param array $expected Expected results
-     * @param array $input    Input
+     * @param array $dsSettings Datasource settings
+     * @param array $tests      Titles and results
      *
      * @dataProvider getTestTitleYearRange
      *
      * @return void
      */
-    public function testTitleYearRange($expected, $input)
+    public function testTitleYearRange($dsSettings, $tests)
     {
-        $this->assertEquals($expected, $input);
+        foreach ($tests as $test) {
+            $this->modifyAhaa14Fixture($test['title']);
+            $record = $this->createRecord(
+                Ead3::class,
+                'ahaa14.xml',
+                $dsSettings,
+                'Finna'
+            )->toSolrArray();
+            $this->assertEquals($test['expected'], $record['title']);
+        }
+        $this->modifyAhaa14Fixture("%%title%%");
     }
 
     /**

--- a/tests/RecordManagerTest/Finna/Record/Ead3Test.php
+++ b/tests/RecordManagerTest/Finna/Record/Ead3Test.php
@@ -234,24 +234,26 @@ class Ead3Test extends \RecordManagerTest\Base\Record\RecordTest
     }
 
     /**
-     * Helper function for getTestTitleYearRange
+     * Helper function for setting new values into XML tags.
      *
-     * @param string $newTitle new title for test case
+     * @param string $fixture  Fixture to modify
+     * @param string $replace  What XML tag is to be changed
+     * @param string $newValue New value for the replace XML element
      *
-     * @return void
+     * @return string
      */
-    public function modifyAhaa14Fixture($newTitle)
-    {
-        $fixture = $this->getFixture('record/ahaa14.xml', 'Finna');
-        $fixturePath = $this->getFixturePath('record/ahaa14.xml', 'Finna');
-        $titleReg = '/>(.*?)<\/unittitle>/';
-        $title = ">" . $newTitle . "</unittitle>";
-        $fixture = preg_replace(
-            $titleReg,
-            $title,
+    public function getFixtureWithNewValue(
+        string $fixture,
+        string $replace,
+        string $newValue
+    ): string {
+        $oldTag = "/>(.*?)<\/$replace>/";
+        $newTag = ">" . $newValue . "</$replace>";
+        return preg_replace(
+            $oldTag,
+            $newTag,
             $fixture
         );
-        file_put_contents($fixturePath, $fixture);
     }
 
     /**
@@ -265,57 +267,57 @@ class Ead3Test extends \RecordManagerTest\Base\Record\RecordTest
         $mdash = html_entity_decode('&#x2014;', ENT_NOQUOTES, 'UTF-8');
 
         $noYear = [
-            'test ndash' => [
+            'no year ndash' => [
                 'title' => "Opintokirja. Helsingin yliopisto (1932{$ndash}1935)",
                 'expected' => "Opintokirja. Helsingin yliopisto (1932{$ndash}1935)",
             ],
-            'test mdash' => [
+            'no year mdash' => [
                 'title' => "Opintokirja. Helsingin yliopisto 1932{$mdash}1935",
                 'expected' => "Opintokirja. Helsingin yliopisto 1932{$mdash}1935",
             ],
-            'test dash' => [
+            'no year dash' => [
                 'title' => "Opintokirja. Helsingin yliopisto (1932 - 1935)",
                 'expected' => "Opintokirja. Helsingin yliopisto (1932 - 1935)",
             ],
-            'test dash without whitespaces' => [
-                'title' => "Opintokirja. Helsingin yliopisto 1932-1935",
-                'expected' => "Opintokirja. Helsingin yliopisto 1932-1935",
+            'no year with year' => [
+                'title' => "Opintokirja. Helsingin yliopisto 1932",
+                'expected' => "Opintokirja. Helsingin yliopisto 1932",
             ],
-            'test without year range' => [
+            'no year without year range' => [
                 'title' => "Opintokirja. Helsingin yliopisto",
                 'expected' => "Opintokirja. Helsingin yliopisto (1932{$ndash}1935)",
             ],
         ];
 
         $never = [
-            'test ndash' => [
+            'never ndash' => [
                 'title' => "Opintokirja. Helsingin yliopisto (1932{$ndash}1935)",
                 'expected' => "Opintokirja. Helsingin yliopisto (1932{$ndash}1935)",
             ],
-            'test without year range' => [
+            'never without year range' => [
                 'title' => "Opintokirja. Helsingin yliopisto",
                 'expected' => "Opintokirja. Helsingin yliopisto",
             ]
         ];
 
         $noMatch = [
-            'test ndash' => [
+            'no match ndash' => [
                 'title' => "Opintokirja. Helsingin yliopisto (1932{$ndash}1935)",
                 'expected' => "Opintokirja. Helsingin yliopisto (1932{$ndash}1935)",
             ],
-            'test mdash' => [
+            'no match mdash' => [
                 'title' => "Opintokirja. Helsingin yliopisto 1932{$mdash}1935",
                 'expected' => "Opintokirja. Helsingin yliopisto 1932{$mdash}1935",
             ],
-            'test dash' => [
+            'no match dash' => [
                 'title' => "Opintokirja. Helsingin yliopisto (1932 - 1935)",
                 'expected' => "Opintokirja. Helsingin yliopisto (1932 - 1935)",
             ],
-            'test dash without whitespaces' => [
+            'no match dash without whitespaces' => [
                 'title' => "Opintokirja. 1932 Helsingin yliopisto",
                 'expected' => "Opintokirja. 1932 Helsingin yliopisto",
             ],
-            'test without year range' => [
+            'no match without year range' => [
                 'title' => "Opintokirja. Helsingin yliopisto",
                 'expected' => "Opintokirja. Helsingin yliopisto (1932{$ndash}1935)",
             ],
@@ -337,7 +339,7 @@ class Ead3Test extends \RecordManagerTest\Base\Record\RecordTest
             ],
             'no matches with years' => [
                 'title' => "Opintokirja. 1932 Helsingin yliopisto 1935",
-                'expected' => "Opintokirja. 1932 Helsingin yliopisto 1935 (1932{$ndash}1935)",
+                'expected' => "Opintokirja. 1932 Helsingin yliopisto 1935",
             ],
             'no matches without years' => [
                 'title' => "Opintokirja. Helsingin yliopisto",
@@ -348,17 +350,21 @@ class Ead3Test extends \RecordManagerTest\Base\Record\RecordTest
         $always = [
             'always ndash' => [
                 'title' => "Opintokirja. Helsingin yliopisto (1932{$ndash}1935)",
-                'expected' => "Opintokirja. Helsingin yliopisto (1932{$ndash}1935)",
+                'expected' =>
+                    "Opintokirja. Helsingin yliopisto "
+                    . "(1932{$ndash}1935) (1932{$ndash}1935)",
             ],
             'always mdash' => [
                 'title' => "Opintokirja. Helsingin yliopisto 1932{$mdash}1935",
                 'expected'
-                    => "Opintokirja. Helsingin yliopisto 1932{$mdash}1935 (1932{$ndash}1935)",
+                    => "Opintokirja. Helsingin yliopisto "
+                    . "1932{$mdash}1935 (1932{$ndash}1935)",
             ],
             'always dash' => [
                 'title' => "Opintokirja. Helsingin yliopisto (1932 - 1935)",
                 'expected' =>
-                    "Opintokirja. Helsingin yliopisto (1932 - 1935) (1932{$ndash}1935)",
+                    "Opintokirja. Helsingin yliopisto "
+                    . "(1932 - 1935) (1932{$ndash}1935)",
             ],
             'always title with a year' => [
                 'title' => "Opintokirja. 1932 Helsingin yliopisto",
@@ -373,52 +379,33 @@ class Ead3Test extends \RecordManagerTest\Base\Record\RecordTest
 
         return [
             [
-                'dsSettings' => [
-                    '__unit_test_no_source__' => [
-                        'driverParams' => [
-                            'enrichTitleWithYearRange=noyearexists'
-                        ]
-                    ]
+                'driverParams' => [
+                    'enrichTitleWithYearRange=noyearexists'
                 ],
                 'tests' => $noYear
             ],
             [
-                'dsSettings' => [
-                    '__unit_test_no_source__' => [
-                        'driverParams' => [
-                            'enrichTitleWithYearRange=never'
-                        ]
-                    ]
+                'driverParams' => [
+                    'enrichTitleWithYearRange=never'
                 ],
                 'tests' => $never
             ],
             [
-                'dsSettings' => [
-                    '__unit_test_no_source__' => [
-                        'driverParams' => [
-                            'enrichTitleWithYearRange=nomatchexists'
-                        ]
-                    ]
+                'driverParams' => [
+                    'enrichTitleWithYearRange=nomatchexists'
                 ],
                 'tests' => $noMatch
             ],
             [
-                'dsSettings' => [
-                    '__unit_test_no_source__' => [
-                        'driverParams' => [
-                            'enrichTitleWithYearRange=nomatchesexists'
-                        ]
-                    ]
+
+                'driverParams' => [
+                    'enrichTitleWithYearRange=nomatchesexists'
                 ],
                 'tests' => $noMatches
             ],
             [
-                'dsSettings' => [
-                    '__unit_test_no_source__' => [
-                        'driverParams' => [
-                            'enrichTitleWithYearRange=always'
-                        ]
-                    ]
+                'driverParams' => [
+                    'enrichTitleWithYearRange=always'
                 ],
                 'tests' => $always
             ],
@@ -428,26 +415,33 @@ class Ead3Test extends \RecordManagerTest\Base\Record\RecordTest
     /**
      * Test AHAA EAD3 title year range handling
      *
-     * @param array $dsSettings Datasource settings
-     * @param array $tests      Titles and results
+     * @param array $driverParams Datasource settings
+     * @param array $tests        Titles and results
      *
      * @dataProvider getTestTitleYearRange
      *
      * @return void
      */
-    public function testTitleYearRange($dsSettings, $tests)
+    public function testTitleYearRange($driverParams, $tests)
     {
+        $fixture = $this->getFixture('record/ahaa14.xml', 'Finna');
         foreach ($tests as $test) {
-            $this->modifyAhaa14Fixture($test['title']);
-            $record = $this->createRecord(
+            $fixture = $this->getFixtureWithNewValue(
+                $fixture,
+                'unittitle',
+                $test['title']
+            );
+            $record = $this->createRecordFromString(
+                $fixture,
                 Ead3::class,
-                'ahaa14.xml',
-                $dsSettings,
-                'Finna'
+                [
+                    '__unit_test_no_source__' => [
+                        'driverParams' => $driverParams
+                    ]
+                ]
             )->toSolrArray();
             $this->assertEquals($test['expected'], $record['title']);
         }
-        $this->modifyAhaa14Fixture("%%title%%");
     }
 
     /**

--- a/tests/RecordManagerTest/Finna/Record/Ead3Test.php
+++ b/tests/RecordManagerTest/Finna/Record/Ead3Test.php
@@ -310,6 +310,8 @@ class Ead3Test extends \RecordManagerTest\Base\Record\RecordTest
             "Opintokirja. Helsingin yliopisto (1932{$ndash}1935)",
             $record['title']
         ];
+        // Set the fixture title to its original state after tests
+        $this->modifyAhaa14Fixture("%%title%%");
     }
 
     /**

--- a/tests/RecordManagerTest/Finna/Record/Ead3Test.php
+++ b/tests/RecordManagerTest/Finna/Record/Ead3Test.php
@@ -380,7 +380,7 @@ class Ead3Test extends \RecordManagerTest\Base\Record\RecordTest
         return [
             [
                 'driverParams' => [
-                    'enrichTitleWithYearRange=no_year_exist'
+                    'enrichTitleWithYearRange=no_year_exists'
                 ],
                 'tests' => $noYear
             ],
@@ -392,7 +392,7 @@ class Ead3Test extends \RecordManagerTest\Base\Record\RecordTest
             ],
             [
                 'driverParams' => [
-                    'enrichTitleWithYearRange=no_match_exist'
+                    'enrichTitleWithYearRange=no_match_exists'
                 ],
                 'tests' => $noMatch
             ],


### PR DESCRIPTION
There are now 5 different ways to determine when to include year range into a title:

         * always = Always add year range to end of a title
         * never = Do not add year range to end of a title
         * no_year_exist = If any year is found from the title then do not add
         * no_match_exist = If any of the given years in unitDateRange are ound from the title, then do not add
         * no_matches_exist = If all of the given years in unitDateRange are found from the title, then do not add
Defaults to no_match_exist

Tests do not modify the file when running them.