### PR TITLE
Adjust getRepositoryLocations function name

### DIFF
--- a/src/RecordManager/Finna/Record/Lido.php
+++ b/src/RecordManager/Finna/Record/Lido.php
@@ -284,7 +284,7 @@ class Lido extends \RecordManager\Base\Record\Lido
             }
         }
         $data['location_geo'] = [
-            ...$this->getEventPlaceLocations(),
+            ...$this->getEventPlaceLocationCoordinates(),
             ...$this->getRepositoryLocationCoordinates(),
         ];
         $data['center_coords']
@@ -1031,7 +1031,7 @@ class Lido extends \RecordManager\Base\Record\Lido
      *
      * @return array<int, string> WKT
      */
-    protected function getEventPlaceLocations($event = null)
+    protected function getEventPlaceLocationCoordinates($event = null)
     {
         $results = [];
         foreach ($this->getEventNodes($event) as $event) {

--- a/src/RecordManager/Finna/Record/Lido.php
+++ b/src/RecordManager/Finna/Record/Lido.php
@@ -544,7 +544,7 @@ class Lido extends \RecordManager\Base\Record\Lido
     }
 
     /**
-     * Get repository locations as coordinates
+     * Get repository location coordinates
      *
      * @return array<int, string>
      */

--- a/src/RecordManager/Finna/Record/Lido.php
+++ b/src/RecordManager/Finna/Record/Lido.php
@@ -285,7 +285,7 @@ class Lido extends \RecordManager\Base\Record\Lido
         }
         $data['location_geo'] = [
             ...$this->getEventPlaceLocations(),
-            ...$this->getRepositoryLocations(),
+            ...$this->getRepositoryLocationCoordinates(),
         ];
         $data['center_coords']
             = $this->metadataUtils->getCenterCoordinates($data['location_geo']);
@@ -548,7 +548,7 @@ class Lido extends \RecordManager\Base\Record\Lido
      *
      * @return array<int, string>
      */
-    protected function getRepositoryLocations(): array
+    protected function getRepositoryLocationCoordinates(): array
     {
         $results = [];
         foreach (

--- a/src/RecordManager/Finna/Record/Lido.php
+++ b/src/RecordManager/Finna/Record/Lido.php
@@ -1025,7 +1025,7 @@ class Lido extends \RecordManager\Base\Record\Lido
     }
 
     /**
-     * Return the event place locations associated with specified event
+     * Return the event place coordinates associated with specified event
      *
      * @param string|array $event Event type(s) allowed (null = all types)
      *

--- a/src/RecordManager/Finna/Record/Lido.php
+++ b/src/RecordManager/Finna/Record/Lido.php
@@ -284,7 +284,7 @@ class Lido extends \RecordManager\Base\Record\Lido
             }
         }
         $data['location_geo'] = [
-            ...$this->getEventPlaceLocationCoordinates(),
+            ...$this->getEventPlaceCoordinates(),
             ...$this->getRepositoryLocationCoordinates(),
         ];
         $data['center_coords']
@@ -1031,7 +1031,7 @@ class Lido extends \RecordManager\Base\Record\Lido
      *
      * @return array<int, string> WKT
      */
-    protected function getEventPlaceLocationCoordinates($event = null)
+    protected function getEventPlaceCoordinates($event = null)
     {
         $results = [];
         foreach ($this->getEventNodes($event) as $event) {

--- a/src/RecordManager/Finna/Record/Lido.php
+++ b/src/RecordManager/Finna/Record/Lido.php
@@ -544,7 +544,7 @@ class Lido extends \RecordManager\Base\Record\Lido
     }
 
     /**
-     * Get repository locations
+     * Get repository locations as coordinates
      *
      * @return array<int, string>
      */


### PR DESCRIPTION
Seems like base now has a getRepositoryLocations function with different logic so renamed this one to be more precise.