### PR TITLE
[FINNA-2022] Return URIs in LIDO::getRawGeographicTopicIds

### DIFF
--- a/src/RecordManager/Finna/Record/Lido.php
+++ b/src/RecordManager/Finna/Record/Lido.php
@@ -434,11 +434,14 @@ class Lido extends \RecordManager\Base\Record\Lido
     {
         $result = [];
         foreach ($this->getPlaceIDElements() as $placeID) {
-            $id = trim((string)$placeID);
-            if (
-                !preg_match('/^https?:/', $id)
-                && $type = (string)($placeID['type'] ?? '')
-            ) {
+            if (!($id = trim((string)$placeID))) {
+                continue;
+            }
+            if (preg_match('/^https?:/', $id)) {
+                $result[] = $id;
+                continue;
+            }
+            if ($type = (string)($placeID['type'] ?? '')) {
                 $result[] = "($type)$id";
             }
         }

--- a/tests/RecordManagerTest/Finna/Record/LidoTest.php
+++ b/tests/RecordManagerTest/Finna/Record/LidoTest.php
@@ -174,7 +174,7 @@ class LidoTest extends \RecordManagerTest\Base\Record\RecordTestBase
             'geographic_id_str_mv' => [
                 '(prt)Prt',
                 '(kiinteistötunnus)Kiinteistötunnus',
-                '(URI)Uri and Yso',
+                'http://www.yso.fi/onto/yso/p94413',
             ],
             'collection' => 'Kansatieteen kuvakokoelma',
             'thumbnail' => 'http://muisti.nba.fi/m/4878_1/00013199.jpg',
@@ -198,7 +198,7 @@ class LidoTest extends \RecordManagerTest\Base\Record\RecordTestBase
                 'Repository Location 2',
                 'Prt',
                 'Kiinteistötunnus',
-                'Uri and Yso',
+                'http://www.yso.fi/onto/yso/p94413',
                 'valmistus',
                 'Hintze Harry',
                 '1897',
@@ -291,7 +291,6 @@ class LidoTest extends \RecordManagerTest\Base\Record\RecordTestBase
                 '4878:1',
                 'Prt',
                 'Kiinteistötunnus',
-                'Uri and Yso',
             ],
         ];
 

--- a/tests/fixtures/Finna/record/musketti2.xml
+++ b/tests/fixtures/Finna/record/musketti2.xml
@@ -77,7 +77,8 @@
                             </namePlaceSet>
                             <placeID type="prt" source="YSO">Prt</placeID>
                             <placeID type="kiinteist&#xF6;tunnus" source="Kiinteist&#xF6;rekisteri">Kiinteistötunnus</placeID>
-                            <placeID type="URI" source="YSO">Uri and Yso</placeID>
+                            <placeID type="URI" source="YSO">http://www.yso.fi/onto/yso/p94413</placeID>
+                            <placeID type="URI" source="YSO"><!-- Empty value should not appear --></placeID>
                         </repositoryLocation>
                     </repositorySet>
                 </repositoryWrap>


### PR DESCRIPTION
Added urls into raw geographic topic ids and left the prefix out of them as it seems it is the same case with other formats. Also discards empty placeids properly.