### PR TITLE
[FINNA-2032] LIDO: Fix enriching coordinates

### DIFF
--- a/tests/RecordManagerTest/Finna/Record/LidoTest.php
+++ b/tests/RecordManagerTest/Finna/Record/LidoTest.php
@@ -639,5 +639,13 @@ class LidoTest extends \RecordManagerTest\Base\Record\RecordTestBase
             ],
         ];
         $this->compareArray($expected, $result, 'Locations');
+
+        $result = ($record instanceof Lido) ? $record->getRawGeographicTopicIds() : [];
+        $expected = [
+            'http://www.yso.fi/onto/yso/p94191',
+            'http://www.yso.fi/onto/yso/p94124',
+            'http://www.yso.fi/onto/yso/p94137',
+        ];
+        $this->compareArray($expected, $result, 'RawGeographicTopicIds');
     }
 }

--- a/tests/fixtures/Finna/record/lido_locations.xml
+++ b/tests/fixtures/Finna/record/lido_locations.xml
@@ -7,6 +7,7 @@
         <repositoryWrap>
           <repositorySet type="Current location">
             <repositoryLocation>
+              <placeID type="URI" source="YSO">http://www.yso.fi/onto/yso/p94137</placeID>
               <namePlaceSet>
                 <appellationValue label="tarkempi paikka">Should not display</appellationValue>
               </namePlaceSet>
@@ -34,6 +35,7 @@
               <subjectPlace>
                 <displayPlace lang="fi">Pohjantie, Karjaa, Etelä-Uusimaa, Suomi</displayPlace>
                 <place>
+                  <placeID type="URI" source="YSO">http://www.yso.fi/onto/yso/p94191</placeID>
                   <namePlaceSet>
                     <appellationValue label="katuosoite">Pohjantie</appellationValue>
                   </namePlaceSet>
@@ -66,6 +68,9 @@
             <subject>
               <subjectPlace>
                 <displayPlace>Suomi, Hamina; Hamina</displayPlace>
+                <place>
+                  <placeID>http://www.yso.fi/onto/yso/p94124</placeID>
+                </place>
               </subjectPlace>
             </subject>
           </subjectSet>
@@ -97,6 +102,7 @@
           <subjectSet>
             <subjectPlace>
               <place>
+                <placeID type="URI" source="YSO">http://www.yso.fi/onto/yso/p105096</placeID>
                 <namePlaceSet>
                   <appellationValue><!-- Kuvausmaa -->Suomi</appellationValue>
                 </namePlaceSet>


### PR DESCRIPTION
- Fix geocoding from displayPlace when there are no hierarchical place names
- Use geographic topic ids for enrichment only if there are no coordinates for the place