### PR TITLE
Adjust linkingid prefix to read datasource specific configuration in proper situations

### DIFF
--- a/src/RecordManager/Finna/Record/Marc.php
+++ b/src/RecordManager/Finna/Record/Marc.php
@@ -227,7 +227,7 @@ class Marc extends \RecordManager\Base\Record\Marc
             $recordCallback,
             $formatCalculator
         );
-        $this->recordLinkingIdFields = $config['MarcRecord']['record_linking_id_fields'] ?? '001,0:035a:999c';
+        $this->recordLinkingIdFields = $config['MarcRecord']['record_linking_id_fields'] ?? '001,0:035a:999c,0';
 
         $this->recordPluginManager = $recordPluginManager;
         $this->initMediaTypeTrait($config);
@@ -1005,10 +1005,16 @@ class Marc extends \RecordManager\Base\Record\Marc
         $datasourcePrefixSetting = $this->getDriverParam('003InLinkingID', null);
 
         foreach ($linkingIds as $idPiped) {
+            // Explode the setting 0 => field and subfield, 1 => prefix with value from 003
             $fieldSpec = explode(',', $idPiped, 2);
             $field = substr($fieldSpec[0], 0, 3);
+            // Try to get the subfield from field
             $subField = $fieldSpec[0][3] ?? null;
-            $prefix = !isset($datasourcePrefixSetting) && isset($fieldSpec[1]) ? $fieldSpec[1] : null;
+            $prefix = $fieldSpec[1] ?? null;
+            // Only use prefix from datasource if the prefix setting has been declared in the global setting.
+            if (null !== $prefix && null !== $datasourcePrefixSetting) {
+                $prefix = $datasourcePrefixSetting;
+            }
             if (!$field) {
                 $this->logger->logDebug(
                     'Marc',

--- a/tests/RecordManagerTest/Finna/Record/MarcTest.php
+++ b/tests/RecordManagerTest/Finna/Record/MarcTest.php
@@ -1425,6 +1425,36 @@ class MarcTest extends \RecordManagerTest\Base\Record\RecordTestBase
                     '123',
                 ],
             ],
+            'koha datasource with 003InLinkingID set to true' => [
+                'marc5.xml',
+                [
+                    '__unit_test_no_source__' => [
+                        'driverParams' => [
+                            'idIn999=true',
+                            'kohaNormalization=true',
+                            '003InLinkingID=true',
+                        ],
+                    ],
+                ],
+                [
+                    '(FI-MELINDA)010101',
+                ],
+            ],
+            'koha datasource with 003InLinkingID set to false' => [
+                'marc5.xml',
+                [
+                    '__unit_test_no_source__' => [
+                        'driverParams' => [
+                            'idIn999=true',
+                            'kohaNormalization=true',
+                            '003InLinkingID=false',
+                        ],
+                    ],
+                ],
+                [
+                    '010101',
+                ],
+            ],
             'koha datasource with id in 999' => [
                 'marc5.xml',
                 [


### PR DESCRIPTION
- Only use the 003InLinkingID if the global linking id setting has declared the setting to be used. This avoids setting prefix to fields which already contains prefixes i.e 035a.